### PR TITLE
Definition : fix a few typos and add a couple of restrictions on groups

### DIFF
--- a/lib/DBIx/Class/EasyFixture/Definition.pm
+++ b/lib/DBIx/Class/EasyFixture/Definition.pm
@@ -74,7 +74,10 @@ around 'BUILDARGS' => sub {
 sub BUILD {
     my $self = shift;
 
-    unless ( $self->group ) {
+    if ( $self->group ) {
+        $self->_validate_group;
+    }
+    else {
         $self->_validate_keys;
         $self->_validate_class_and_data;
         $self->_validate_next;
@@ -87,6 +90,18 @@ sub constructor_data { shift->definition->{using} }
 sub next             { shift->definition->{next} }
 sub requires         { shift->definition->{requires} }
 
+sub _validate_group {
+    my $self  = shift;
+    my $name  = $self->name;
+    my @group = @{ $self->group };    # shallow copy currently ok
+    unless ( @group ) {
+        croak("Fixture '$name' defines an empty group");
+    }
+    if ( my @unknown = sort grep { ! $self->fixture_exists($_) } @group ) {
+        croak("Fixture '$name'.group had unknown fixtures: @unknown");
+    }
+
+}
 sub _validate_keys {
     my $self       = shift;
     my $name       = $self->name;

--- a/t/definitions.t
+++ b/t/definitions.t
@@ -49,8 +49,7 @@ ok !defined $definition->requires,
   '... and no requirements if they are not defined';
 
 subtest 'exceptions' => sub {
-    subtest 'definition build' => sub {
-        my %ignore = ( new => 'Foo', using => { bar => 1 } );
+    subtest 'definition constructor' => sub {
         throws_ok {
             Definition->new(
                 name       => "bob",
@@ -69,6 +68,26 @@ subtest 'exceptions' => sub {
         }
         qr/bob.foo_id malformed: foo bar baz/,
           'Having more than 2 elements in requires should fail';
+    };
+    subtest 'definition group' => sub {
+        throws_ok {
+            Definition->new(
+                name       => "bob",
+                definition => [],
+                fixtures   => { bob => 1 },
+            );
+        }
+        qr/Fixture 'bob' defines an empty group/,
+          'Having an empty group should fail';
+        throws_ok {
+            Definition->new(
+                name       => "bob",
+                definition => [qw(larry damian)],
+                fixtures   => { bob => 1 },
+            );
+        }
+        qr/Fixture 'bob'.group had unknown fixtures: damian larry/,
+          'Having a group using unknown fixtures should fail';
     };
     subtest 'definition class and data' => sub {
         throws_ok {


### PR DESCRIPTION
Current restrictions in group are :
- no empty groups
- no unknown fixtures

Tests were added to cover the changes.
