### PR TITLE
POD fixed

### DIFF
--- a/lib/DBIx/Class/EasyFixture.pm
+++ b/lib/DBIx/Class/EasyFixture.pm
@@ -493,3 +493,5 @@ that later when it becomes more clear how to best handle them.
 
 Track what fixtures are requested and what fixtures are loaded (and in which
 order).  This makes for better error reporting.
+
+=back


### PR DESCRIPTION
In the generated POD, Author and Copyright sections are added, so we
have to end the =over with a =back.
